### PR TITLE
getBuildNumber includes an illegal negative index access

### DIFF
--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -81,10 +81,11 @@ class HttpHandler implements Disposable {
       host: "discord.com",
       path: "/login",
     ));
+    final assetResMatches = assetRegex.allMatches(res.body).toList();
     http.Response assetRes = await httpClient.get(Uri(
       scheme: "https",
       host: "discord.com",
-      path: "/assets/${assetRegex.allMatches(res.body).toList()[0]}.js",
+      path: "/assets/${assetResMatches[assetResMatches.length - 2]}.js",
     ));
     int buildIndex = assetRes.body.indexOf("buildNumber") + 24;
     return int.tryParse(assetRes.body.substring(buildIndex, buildIndex + 6)) ?? 9999;

--- a/lib/src/internal/http/http_handler.dart
+++ b/lib/src/internal/http/http_handler.dart
@@ -84,7 +84,7 @@ class HttpHandler implements Disposable {
     http.Response assetRes = await httpClient.get(Uri(
       scheme: "https",
       host: "discord.com",
-      path: "/assets/${assetRegex.allMatches(res.body).toList()[-2]}.js",
+      path: "/assets/${assetRegex.allMatches(res.body).toList()[0]}.js",
     ));
     int buildIndex = assetRes.body.indexOf("buildNumber") + 24;
     return int.tryParse(assetRes.body.substring(buildIndex, buildIndex + 6)) ?? 9999;


### PR DESCRIPTION
I had having persistent issues with my Flutter project until I changed this from -2 to 0. This really should just be 0. Issue occurred both on Mac and Windows.